### PR TITLE
Get GITHUB_TOKEN env variable as Github access token before getting it from config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ $ tosa <sha>
 -v, --version  Print current version.
 ```
 
-*NOTE*: Only first time, `tosa` requires your Github username and password(and two-factor auth code if you are setting). Because of using [GitHub API v3](https://developer.github.com/v3/).
+*NOTE*: Set Github Access Token which has "Full control of private repositories" scope as an environment variable `GITHUB_TOKEN`. If not set, `tosa` requires your Github username and password(and two-factor auth code if you are setting). Because of using [GitHub API v3](https://developer.github.com/v3/).
+
 
 ### from tig
 


### PR DESCRIPTION
The order getting Github access token is 

1. From `GITHUB_TOKEN` env variable
1. (If not set) From `$HOME/config/tosa`